### PR TITLE
Feat: 헤더에 쿠키담아 보내는 작업 정리

### DIFF
--- a/src/app/auth/google/callback/page.tsx
+++ b/src/app/auth/google/callback/page.tsx
@@ -19,9 +19,11 @@ function Page() {
 
   const apiTest = async () => {
     try {
-      const data = await axios.get(`${baseURL}/users/info`).then(res => {
-        console.log('res', res)
-      })
+      const data = await axios
+        .get(`${baseURL}/users/info`, { withCredentials: true })
+        .then(res => {
+          console.log('res', res)
+        })
     } catch (err) {
       console.log('err', err)
     }

--- a/src/utils/httpClient.ts
+++ b/src/utils/httpClient.ts
@@ -10,17 +10,13 @@ import useUserStore from '@/states/user-store/userStore'
 
 const axiosInstance: AxiosInstance = axios.create({
   baseURL: process.env.NEXT_PUBLIC_API_BASE_URL,
-  withCredentials: true,
+  // withCredentials: true, 작동 X
   timeout: 5000,
 })
 
 const retryCountMap = new Map<string, { count: number; timestamp: number }>()
 
 axiosInstance.interceptors.request.use(config => {
-  const token = Cookies.get('access-token')
-  console.log('token', token)
-  config.headers.Authorization = token ? `Bearer ${token}` : ''
-
   const reqId = uuidv4()
   config.headers['X-Request-ID'] = reqId
 


### PR DESCRIPTION
- axiods instance create에 작성한 withCredentails는 작동하지않음
- get요청을 할 때 withCredentails를 설정해 줘야함
- 쿠키는 자동으로  넘어간다.