### PR TITLE
Docs: og url제거

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -14,7 +14,6 @@ export const metadata: Metadata = {
     description:
       '화면 캡쳐를 위해 QA를 멈추지 마세요! 실시간 북마크를 통해 QA를 더 빠르고 정확하게! QAing과 함께 시간을 단축하세요!',
     type: 'website',
-    url: 'https://www.qaing.co',
     images: [
       {
         url: 'https://uploads-ssl.webflow.com/655473960208081b667f8383/658d257f383d9bd0af678c4c_QAing.png',


### PR DESCRIPTION
- 카카오톡 공유시 이미지가 설정한데로 보여지지 않아서 url을 제거후 test에정